### PR TITLE
Automatic documentation deployment on Github pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,56 @@
+name: Deploy documentation on GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+
+      - name: Upgrade pip
+        run: |
+          # install pip=>20.1 to use "pip cache dir"
+          python3 -m pip install --upgrade pip
+
+      - name: Get pip cache dir
+        id: pip-cache
+        run: echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install doc dependencies
+        run: python3 -m pip install -r ./doc/requirements.txt
+
+      - name: Install mininet and ryu from source
+        run: python3 -m pip install git+https://github.com/mininet/mininet.git git+https://github.com/faucetsdn/ryu.git@v4.34
+
+      - name: Install all other dependencies
+        run: python3 -m pip install wheel docker pyroute2 requests
+
+      - name: Build docs
+        working-directory: "./doc"
+        run: sphinx-build -M html . ./build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/master' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./doc/build/html


### PR DESCRIPTION
I might as well contribute something to this cool project! This PR adds a Github workflow which sets up Python + `comnetsemu` dependencies, generates the documentation in the same way `doc/Makefile` does and deploys it to the `gh-pages` branch on every push to the `master` branch.