### PR TITLE
Fixing the echo_server example to be compatible with the Book Chapter 13

### DIFF
--- a/examples/echo_server/topology.py
+++ b/examples/echo_server/topology.py
@@ -40,10 +40,8 @@ if __name__ == "__main__":
     info("\n*** Starting network\n")
     net.start()
 
-    srv1 = mgr.addContainer(
-        "srv1", "h1", "echo_server", "python /home/server.py", docker_args={}
-    )
-    srv2 = mgr.addContainer("srv2", "h2", "dev_test", "bash", docker_args={})
+    srv2 = mgr.addContainer("srv1", "h1", "dev_test", "bash", docker_args={})
+    srv1 = mgr.addContainer( "srv2", "h2", "echo_server", "python /home/server.py", docker_args={} )
 
     if not AUTOTEST_MODE:
         # Cannot spawn xterm for srv1 since BASH is not installed in the image:

--- a/test_containers/Dockerfile.dev_test
+++ b/test_containers/Dockerfile.dev_test
@@ -24,6 +24,7 @@ RUN apt-get -qy update && \
 	net-tools \
 	stress-ng \
 	tcpdump \
+	netcat \
 	telnet && \
 	rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
nc command was missing in the test_dev docker image.